### PR TITLE
fix(core): eagerly drain response body to avoid leaking keepAlive sockets

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -54,6 +54,10 @@ type APIResponseProps = {
   response: Response;
   options: FinalRequestOptions;
   controller: AbortController;
+  // The response body, read eagerly in `makeRequest` (see the comment
+  // there for why). Absent only for 204s and `__binaryResponse` requests,
+  // where the raw `Response` stream is left untouched on purpose.
+  bodyText?: string | undefined;
 };
 
 async function defaultParseResponse<T>(props: APIResponseProps): Promise<T> {
@@ -70,21 +74,24 @@ async function defaultParseResponse<T>(props: APIResponseProps): Promise<T> {
   const contentType = response.headers.get('content-type');
   const mediaType = contentType?.split(';')[0]?.trim();
   const isJSON = mediaType?.includes('application/json') || mediaType?.endsWith('+json');
+
+  // The body was already read in `makeRequest`, so parse from that instead
+  // of calling response.json()/.text() again (the underlying stream can
+  // only be consumed once).
+  const text = props.bodyText ?? '';
   if (isJSON) {
-    const contentLength = response.headers.get('content-length');
-    if (contentLength === '0') {
+    if (text === '') {
       // if there is no content we can't do anything
       return undefined as T;
     }
 
-    const json = await response.json();
+    const json = JSON.parse(text);
 
     debug('response', response.status, response.url, response.headers, json);
 
     return json as T;
   }
 
-  const text = await response.text();
   debug('response', response.status, response.url, response.headers, text);
 
   // TODO handle blob, arraybuffer, other content types, etc.
@@ -488,13 +495,18 @@ export abstract class APIClient {
     const responseHeaders = createResponseHeaders(response.headers);
 
     if (!response.ok) {
+      // This response is being discarded either way (retried or thrown),
+      // so always drain it here rather than leaving it to whichever branch
+      // happens to read it below. Without this, a retried request leaks
+      // the losing response's keep-alive socket on every retry.
+      const errText = await response.text().catch((e) => castToError(e).message);
+
       if (retriesRemaining && this.shouldRetry(response)) {
         const retryMessage = `retrying, ${retriesRemaining} attempts remaining`;
         debug(`response (error; ${retryMessage})`, response.status, url, responseHeaders);
         return this.retryRequest(options, retriesRemaining, responseHeaders);
       }
 
-      const errText = await response.text().catch((e) => castToError(e).message);
       const errJSON = safeJSON(errText);
       const errMessage = errJSON ? undefined : errText;
       const retryMessage = retriesRemaining ? `(error; no more retries left)` : `(error; not retryable)`;
@@ -505,7 +517,49 @@ export abstract class APIClient {
       throw err;
     }
 
-    return { response, options, controller };
+    // Read the body now, regardless of whether the caller ever awaits or
+    // .then()s the APIPromise we're about to return (including callers who
+    // only use .asResponse() and never touch the parsed data). A
+    // keepAlive socket is only returned to the agent's free pool once its
+    // response body has been fully read; leaving that to whenever (if
+    // ever) application code consumes the promise is what let a handful of
+    // long-running /split responses arrive successfully and then sit
+    // unread on an orphaned socket until an unrelated timeout tore down
+    // the connection.
+    //
+    // We read a *clone* rather than `response` itself: `.asResponse()` /
+    // `.withResponse()` are documented, tested ways to get the raw,
+    // independently-readable Response back (callers are expected to be
+    // able to call `.text()`/`.json()` on it themselves), so `response`
+    // must be left untouched. Cloning tees the underlying stream, so our
+    // read below still drains the network/socket side immediately;
+    // `response` stays fully readable later regardless.
+    //
+    // Skipped entirely for `__binaryResponse` requests: that's the
+    // existing escape hatch for callers who want the raw stream without
+    // any of this, e.g. to pipe a large response without buffering it.
+    let bodyText: string | undefined;
+    if (!options.__binaryResponse) {
+      const bodyResult = await response.clone().text().catch(castToError);
+      if (bodyResult instanceof Error) {
+        // The connection dropped (or similar) while reading a response
+        // whose status line already came back ok — treat it the same way
+        // as a failure of the initial fetch itself.
+        if (options.signal?.aborted) {
+          throw new APIUserAbortError();
+        }
+        if (retriesRemaining) {
+          return this.retryRequest(options, retriesRemaining);
+        }
+        if (bodyResult.name === 'AbortError') {
+          throw new APIConnectionTimeoutError();
+        }
+        throw new APIConnectionError({ cause: bodyResult });
+      }
+      bodyText = bodyResult;
+    }
+
+    return { response, options, controller, bodyText };
   }
 
   requestAPIList<Item = unknown, PageClass extends AbstractPage<Item> = AbstractPage<Item>>(

--- a/tests/body-draining.test.ts
+++ b/tests/body-draining.test.ts
@@ -1,0 +1,60 @@
+import * as http from 'http';
+import Reducto from 'reductoai';
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, () => resolve((server.address() as import('net').AddressInfo).port));
+  });
+}
+
+describe('response body draining', () => {
+  let server: http.Server;
+  let port: number;
+
+  beforeEach(async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    port = await listen(server);
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  test('an unconsumed APIPromise still frees its socket for reuse', async () => {
+    // A small pool, like a real caller sharing one Agent across many
+    // concurrent calls. Without eager draining, request #1 below (never
+    // awaited/`.then()`d) permanently occupies its socket, and request #2
+    // queues forever waiting for one to free up.
+    const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
+    const client = new Reducto({
+      apiKey: 'My API Key',
+      baseURL: `http://localhost:${port}/`,
+      httpAgent: agent,
+    });
+
+    // Fire-and-forget: intentionally never awaited, never `.then()`'d,
+    // mirroring an application that drops the promise (or only inspects
+    // `.asResponse()` without reading it) instead of awaiting the parsed
+    // result.
+    client.request({ path: '/foo', method: 'get' });
+
+    // If request #1's socket was never returned to the pool, this hangs
+    // forever. jest's default test timeout bounds that for us.
+    const result = await client.request({ path: '/foo', method: 'get' });
+    expect(result).toEqual({ ok: true });
+  });
+
+  test('.asResponse() still returns a fully readable, independent Response', async () => {
+    const client = new Reducto({ apiKey: 'My API Key', baseURL: `http://localhost:${port}/` });
+
+    const promise = client.request({ path: '/foo', method: 'get' });
+    const response = await promise.asResponse();
+    expect(await response.text()).toEqual(JSON.stringify({ ok: true }));
+
+    // The parsed-data path still works independently of the asResponse() read above.
+    expect(await promise).toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
## Summary

`APIPromise` only reads the response body inside its overridden `.then()`/`.catch()`/`.finally()` (`core.ts`). If a caller never chains onto the returned promise — or only calls `.asResponse()` without also consuming the parsed data — the body is never read. A `keepAlive` socket is only returned to the Agent's free pool once its response has been fully drained, so that socket sits open indefinitely, holding a response that already arrived successfully but is invisible to the application, until something external (a client-side timeout, an ALB connection cap) tears the connection down.

This is what we believe caused a production incident: several long-running `/split` requests completed successfully on the backend, our ALB access logs showed a clean `200` written back to the client immediately (timestamped within ~1s of the backend's own reported completion time, with real response bytes sent), but the caller never observed the response until an unrelated ~1 hour timeout eventually fired. Since the SDK also retries on timeout by default (`maxRetries: 2`), this is a plausible root cause for reprocessed/duplicated jobs as well, not just the hang itself.

## Fix

Drain the body inside `makeRequest`, right after the response arrives — independent of whether or when the caller ever consumes the returned promise:

- **Success path**: read a *clone* of the response (so `.asResponse()`/`.withResponse()` still get a fully independent, readable `Response`, exactly as today — covered by existing tests in `tests/index.test.ts`) and cache the text on `APIResponseProps.bodyText` for `defaultParseResponse` to parse from, instead of re-reading the stream later.
- **Retryable-error path**: also drain before discarding and retrying. This response is abandoned either way once we decide to retry, and previously this path leaked one socket per retry — independent of any caller behavior at all.
- **`__binaryResponse`** requests are left completely untouched, as before (the existing escape hatch for raw/streaming payloads).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Full existing test suite passes unchanged (`npx jest`), including the `retries` suite in `tests/index.test.ts` which explicitly asserts `.asResponse().then(r => r.text())` still works after a retry
- [x] Added `tests/body-draining.test.ts`:
  - A request fired and never awaited/`.then()`'d still frees its socket for the next request over a `maxSockets: 1` agent (hangs without this fix — verified by reverting the `core.ts` change locally and re-running)
  - `.asResponse()` still returns a fully independent, readable `Response` alongside the normal parsed-data path
- [x] Manually reproduced the underlying socket-leak mechanism against a local Node http server + shared `keepAlive` agent before writing this fix, to confirm the failure mode

## Open question for maintainers

`tests/index.test.ts` is marked as generated from the OpenAPI spec via Stainless. I don't know whether this same fix needs to land in the Stainless generator config to survive the next regeneration, or whether hand-patches to `core.ts` persist across releases — worth confirming before merge.